### PR TITLE
Add framework parameter for LangChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ from llmcosts import get_usage_tracker, list_alerts, list_limits
 ```python
 import os
 from llmcosts.tracker import LLMTrackingProxy, Provider
+from llmcosts.tracker.frameworks import Framework
 import openai
 
 client = openai.OpenAI(
@@ -295,14 +296,15 @@ from llmcosts.tracker import LLMTrackingProxy, Provider
 from langchain_openai import OpenAI, ChatOpenAI
 import openai
 
-# Step 1: Create tracked OpenAI client  
+# Step 1: Create tracked OpenAI client with LangChain integration
 openai_client = openai.OpenAI(api_key="your-key")
-tracked_client = LLMTrackingProxy(openai_client, provider=Provider.OPENAI)
+tracked_client = LLMTrackingProxy(
+    openai_client,
+    provider=Provider.OPENAI,
+    framework=Framework.LANGCHAIN,
+)
 
-# Step 2: Enable LangChain compatibility mode
-tracked_client.enable_langchain_mode()
-
-# Step 3: Pass correct sub-clients to LangChain models
+# Step 2: Pass correct sub-clients to LangChain models
 llm = OpenAI(
     client=tracked_client.completions,  # ✅ Use .completions for OpenAI LLM
     model="gpt-3.5-turbo-instruct",
@@ -342,8 +344,11 @@ import openai
 
 # Setup tracked client
 openai_client = openai.OpenAI(api_key="your-key")
-tracked_client = LLMTrackingProxy(openai_client, provider=Provider.OPENAI)
-tracked_client.enable_langchain_mode()  # Enable LangChain compatibility
+tracked_client = LLMTrackingProxy(
+    openai_client,
+    provider=Provider.OPENAI,
+    framework=Framework.LANGCHAIN,
+)
 
 # OpenAI LLM (legacy completions)
 llm = OpenAI(
@@ -483,15 +488,15 @@ response = streaming_chat.invoke([HumanMessage(content="Tell me about the ocean"
 ```python
 # Context tracking for LangChain usage
 tracked_client = LLMTrackingProxy(
-    openai_client, 
+    openai_client,
     provider=Provider.OPENAI,
+    framework=Framework.LANGCHAIN,
     context={
         "framework": "langchain",
         "user_id": "user_123",
         "session_id": "session_456"
     }
 )
-tracked_client.enable_langchain_mode()  # Enable LangChain compatibility
 
 # Response callbacks
 def track_langchain_response(response):
@@ -528,9 +533,9 @@ response = chat_model.invoke([HumanMessage(content="Test")])
    - **OpenAI Completions**: Multiple prompts = 1 API call = 1 usage log
    - **ChatOpenAI**: Multiple messages = Multiple API calls = Multiple usage logs
 
-2. **LangChain Mode Required**:
-   - **Must call** `tracked_client.enable_langchain_mode()` before using with LangChain
-   - This enables automatic `stream_options` injection for seamless streaming
+2. **LangChain Integration**:
+   - Pass ``framework=Framework.LANGCHAIN`` when creating ``LLMTrackingProxy``
+   - This enables automatic ``stream_options`` injection for seamless streaming
    - Without this, streaming calls will raise validation errors
 
 3. **Streaming Requirements**:
@@ -592,8 +597,11 @@ from langchain_openai import ChatOpenAI
 import openai
 
 client = openai.OpenAI(api_key="your-key")
-tracked_client = LLMTrackingProxy(client, provider=Provider.OPENAI)  # Add this line
-tracked_client.enable_langchain_mode()  # Add this line
+tracked_client = LLMTrackingProxy(
+    client,
+    provider=Provider.OPENAI,
+    framework=Framework.LANGCHAIN,
+)  # Add this line
 chat_model = ChatOpenAI(
     client=tracked_client.chat.completions,  # Change this line
     model="gpt-4o-mini",

--- a/llmcosts/__init__.py
+++ b/llmcosts/__init__.py
@@ -70,6 +70,7 @@ from .thresholds import (
 from .tracker import (
     LLMTrackingProxy,
     Provider,
+    Framework,
     UsageTracker,
     get_usage_tracker,
 )
@@ -78,6 +79,7 @@ __all__ = [
     "LLMCostsClient",
     "LLMTrackingProxy",
     "Provider",
+    "Framework",
     "UsageTracker",
     "get_usage_tracker",
     "TriggeredLimitError",

--- a/llmcosts/client.py
+++ b/llmcosts/client.py
@@ -18,7 +18,10 @@ class LLMCostsClient:
     """Simple wrapper around the llmcosts.com REST API."""
 
     def __init__(
-        self, api_key: Optional[str] = None, base_url: Optional[str] = None
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        framework: Optional[str] = None,
     ) -> None:
         env = Env()
         api_key = api_key or env.str("LLMCOSTS_API_KEY", None)
@@ -29,6 +32,7 @@ class LLMCostsClient:
         )
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
+        self.framework = framework
         self.session = requests.Session()
         self.session.headers.update(
             {

--- a/llmcosts/tracker/__init__.py
+++ b/llmcosts/tracker/__init__.py
@@ -1,4 +1,5 @@
 from .providers import Provider
+from .frameworks import Framework
 from .proxy import LLMTrackingProxy
 from .usage_delivery import (
     UsageTracker,
@@ -23,6 +24,7 @@ except Exception:
 __all__ = [
     "LLMTrackingProxy",
     "Provider",
+    "Framework",
     "UsageTracker",
     "get_usage_tracker",
     "reset_global_tracker",

--- a/llmcosts/tracker/frameworks.py
+++ b/llmcosts/tracker/frameworks.py
@@ -1,0 +1,9 @@
+"""Supported third-party frameworks for LLMTrackingProxy."""
+
+from enum import Enum
+
+
+class Framework(Enum):
+    """Enum of supported frameworks."""
+
+    LANGCHAIN = "langchain"

--- a/tests/check.py
+++ b/tests/check.py
@@ -62,6 +62,7 @@ from environs import Env
 
 from llmcosts.tracker import LLMTrackingProxy
 from llmcosts.tracker.providers import Provider
+from llmcosts.tracker.frameworks import Framework
 
 # Load environment variables from .env file in the tests directory
 env = Env()
@@ -197,7 +198,12 @@ def run_manual_test(provider: str, model: str, stream: bool = False) -> None:
         raise ValueError(f"Unknown provider: {provider}")
 
     proxy = LLMTrackingProxy(
-        client, provider=provider_enum, debug=True, sync_mode=True, api_key=api_key
+        client,
+        provider=provider_enum,
+        debug=True,
+        sync_mode=True,
+        api_key=api_key,
+        framework=Framework.LANGCHAIN if provider == "langchain" else None,
     )
 
     try:
@@ -293,9 +299,6 @@ def run_manual_test(provider: str, model: str, stream: bool = False) -> None:
                     "langchain-openai not installed. "
                     "Please install it with: pip install langchain-openai"
                 )
-
-            # Enable LangChain mode for compatibility
-            proxy.enable_langchain_mode()
 
             # Create LangChain model using the tracked chat completions client
             langchain_model = ChatOpenAI(

--- a/tests/test_framework_parameter.py
+++ b/tests/test_framework_parameter.py
@@ -1,0 +1,32 @@
+"""Tests for the new framework parameter in LLMTrackingProxy."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from llmcosts.tracker import LLMTrackingProxy
+from llmcosts.tracker.providers import Provider
+from llmcosts.tracker.frameworks import Framework
+
+
+class MockClient:
+    def __init__(self):
+        self.completions = MagicMock()
+
+
+class TestFrameworkParameter:
+    def test_framework_enables_langchain_mode(self):
+        client = MockClient()
+        proxy = LLMTrackingProxy(client, provider=Provider.OPENAI, framework=Framework.LANGCHAIN)
+        assert proxy._langchain_mode is True
+        # Child proxies inherit
+        child = proxy.completions
+        assert isinstance(child, LLMTrackingProxy)
+        assert child._langchain_mode is True
+
+    def test_framework_default_none(self):
+        client = MockClient()
+        proxy = LLMTrackingProxy(client, provider=Provider.OPENAI)
+        assert proxy._langchain_mode is False
+        assert proxy.framework is None
+

--- a/tests/test_langchain_limit.py
+++ b/tests/test_langchain_limit.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from llmcosts.exceptions import TriggeredLimitError
 from llmcosts.tracker import LLMTrackingProxy
 from llmcosts.tracker.providers import Provider
+from llmcosts.tracker.frameworks import Framework
 
 # Load environment variables from .env file in the tests directory
 env = Env()
@@ -39,9 +40,11 @@ def openai_client():
 def tracked_client(openai_client):
     """Create a tracked OpenAI client for LangChain."""
     tracked_client = LLMTrackingProxy(
-        openai_client, provider=Provider.OPENAI, debug=True
+        openai_client,
+        provider=Provider.OPENAI,
+        debug=True,
+        framework=Framework.LANGCHAIN,
     )
-    tracked_client.enable_langchain_mode()  # Enable LangChain compatibility
     return tracked_client
 
 

--- a/tests/test_langchain_nonstreaming.py
+++ b/tests/test_langchain_nonstreaming.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from llmcosts.tracker import LLMTrackingProxy
 from llmcosts.tracker.providers import Provider
+from llmcosts.tracker.frameworks import Framework
 
 # Load environment variables from .env file in the tests directory
 env = Env()
@@ -41,9 +42,11 @@ class TestLangChainNonStreaming:
     def tracked_openai_client(self, openai_client):
         """Create a tracked OpenAI client for LangChain."""
         tracked_client = LLMTrackingProxy(
-            openai_client, provider=Provider.OPENAI, debug=True
+            openai_client,
+            provider=Provider.OPENAI,
+            debug=True,
+            framework=Framework.LANGCHAIN,
         )
-        tracked_client.enable_langchain_mode()  # Enable LangChain compatibility
         return tracked_client
 
     @pytest.fixture
@@ -65,7 +68,10 @@ class TestLangChainNonStreaming:
         from llmcosts.tracker import LLMTrackingProxy
 
         langchain_llm.client = LLMTrackingProxy(
-            langchain_llm.client, provider=Provider.OPENAI, debug=True
+            langchain_llm.client,
+            provider=Provider.OPENAI,
+            debug=True,
+            framework=Framework.LANGCHAIN,
         )
 
         return langchain_llm
@@ -89,7 +95,10 @@ class TestLangChainNonStreaming:
         from llmcosts.tracker import LLMTrackingProxy
 
         langchain_chat_model.client = LLMTrackingProxy(
-            langchain_chat_model.client, provider=Provider.OPENAI, debug=True
+            langchain_chat_model.client,
+            provider=Provider.OPENAI,
+            debug=True,
+            framework=Framework.LANGCHAIN,
         )
 
         return langchain_chat_model

--- a/tests/test_langchain_streaming.py
+++ b/tests/test_langchain_streaming.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from llmcosts.tracker import LLMTrackingProxy
 from llmcosts.tracker.providers import Provider
+from llmcosts.tracker.frameworks import Framework
 
 # Load environment variables from .env file in the tests directory
 env = Env()
@@ -41,9 +42,11 @@ class TestLangChainStreaming:
     def tracked_openai_client(self, openai_client):
         """Create a tracked OpenAI client for LangChain."""
         tracked_client = LLMTrackingProxy(
-            openai_client, provider=Provider.OPENAI, debug=True
+            openai_client,
+            provider=Provider.OPENAI,
+            debug=True,
+            framework=Framework.LANGCHAIN,
         )
-        tracked_client.enable_langchain_mode()  # Enable LangChain compatibility
         return tracked_client
 
     @pytest.fixture


### PR DESCRIPTION
## Summary
- introduce `Framework` enum
- add optional `framework` argument to `LLMTrackingProxy` and `LLMCostsClient`
- automatically enable LangChain mode when `framework=Framework.LANGCHAIN`
- export `Framework`
- update docs and tests for the new parameter
- include dedicated tests for framework handling
- remove duplicate imports in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for openai/boto3 etc.)*

------
https://chatgpt.com/codex/tasks/task_b_686955b3b4e4832b83cddaaa807c4fd0