### PR TITLE
Add base_url support for OpenAI-compatible APIs

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -168,9 +168,9 @@ deepseek_client = openai.OpenAI(
     base_url="https://api.deepseek.com/v1"
 )
 tracked_deepseek = LLMTrackingProxy(
-    deepseek_client, 
-    provider=Provider.DEEPSEEK,  # REQUIRED: Specifies this is DeepSeek
-    # framework=None by default for direct DeepSeek API usage
+    deepseek_client,
+    provider=Provider.OPENAI,  # OpenAI-compatible API
+    base_url="https://api.deepseek.com/v1",
     api_key=os.environ.get("LLMCOSTS_API_KEY"),
 )
 
@@ -188,13 +188,13 @@ from llmcosts.tracker import LLMTrackingProxy, Provider
 import openai
 
 grok_client = openai.OpenAI(
-    api_key=os.environ.get("XAI_API_KEY"), 
+    api_key=os.environ.get("XAI_API_KEY"),
     base_url="https://api.x.ai/v1"
 )
 tracked_grok = LLMTrackingProxy(
-    grok_client, 
-    provider=Provider.XAI,  # REQUIRED: Specifies this is Grok/xAI
-    # framework=None by default for direct Grok API usage
+    grok_client,
+    provider=Provider.OPENAI,  # OpenAI-compatible API
+    base_url="https://api.x.ai/v1",
     api_key=os.environ.get("LLMCOSTS_API_KEY"),
 )
 

--- a/llmcosts/tracker/openai_handler.py
+++ b/llmcosts/tracker/openai_handler.py
@@ -45,6 +45,7 @@ class OpenAIUsageHandler(UsageHandler):
         # attribute but no `choices` attribute.
         method_owner = str(getattr(attr, "__self__", ""))
         is_responses_api = "responses" in method_owner
+        base_url = kwargs.get("base_url")
 
         if is_responses_api:
             # For Responses API streaming, usage is nested in obj.response.usage
@@ -109,6 +110,9 @@ class OpenAIUsageHandler(UsageHandler):
         # Add service_tier if available
         if hasattr(obj, "service_tier") and obj.service_tier is not None:
             payload["service_tier"] = obj.service_tier
+
+        if base_url:
+            payload["base_url"] = base_url
 
         return self._add_common_fields(payload, obj)
 

--- a/tests/test_deepseek_limit.py
+++ b/tests/test_deepseek_limit.py
@@ -26,7 +26,12 @@ def client():
 
 @pytest.fixture
 def tracked_client(client):
-    return LLMTrackingProxy(client, provider=Provider.DEEPSEEK, debug=True)
+    return LLMTrackingProxy(
+        client,
+        provider=Provider.OPENAI,
+        base_url="https://api.deepseek.com/v1",
+        debug=True,
+    )
 
 
 def _allow():

--- a/tests/test_deepseek_nonstreaming.py
+++ b/tests/test_deepseek_nonstreaming.py
@@ -40,7 +40,12 @@ class TestDeepSeekNonStreaming:
     @pytest.fixture
     def tracked_deepseek_client(self, deepseek_client):
         """Create a tracked DeepSeek client."""
-        return LLMTrackingProxy(deepseek_client, provider=Provider.DEEPSEEK, debug=True)
+        return LLMTrackingProxy(
+            deepseek_client,
+            provider=Provider.OPENAI,
+            base_url="https://api.deepseek.com/v1",
+            debug=True,
+        )
 
     def test_deepseek_chat_completions_non_streaming(
         self, tracked_deepseek_client, caplog

--- a/tests/test_deepseek_streaming.py
+++ b/tests/test_deepseek_streaming.py
@@ -40,7 +40,12 @@ class TestDeepSeekStreaming:
     @pytest.fixture
     def tracked_deepseek_client(self, deepseek_client):
         """Create a tracked DeepSeek client."""
-        return LLMTrackingProxy(deepseek_client, provider=Provider.DEEPSEEK, debug=True)
+        return LLMTrackingProxy(
+            deepseek_client,
+            provider=Provider.OPENAI,
+            base_url="https://api.deepseek.com/v1",
+            debug=True,
+        )
 
     def test_deepseek_chat_completions_streaming(self, tracked_deepseek_client, caplog):
         """Test streaming chat completion with DeepSeek captures usage."""

--- a/tests/test_grok_limit.py
+++ b/tests/test_grok_limit.py
@@ -34,7 +34,12 @@ def client():
 
 @pytest.fixture
 def tracked_client(client):
-    return LLMTrackingProxy(client, provider=Provider.XAI, debug=True)
+    return LLMTrackingProxy(
+        client,
+        provider=Provider.OPENAI,
+        base_url="https://api.x.ai/v1",
+        debug=True,
+    )
 
 
 def _allow():

--- a/tests/test_grok_nonstreaming.py
+++ b/tests/test_grok_nonstreaming.py
@@ -40,7 +40,12 @@ class TestGrokNonStreaming:
     @pytest.fixture
     def tracked_grok_client(self, grok_client):
         """Create a tracked Grok client."""
-        return LLMTrackingProxy(grok_client, provider=Provider.XAI, debug=True)
+        return LLMTrackingProxy(
+            grok_client,
+            provider=Provider.OPENAI,
+            base_url="https://api.x.ai/v1",
+            debug=True,
+        )
 
     def test_grok_3_mini_model(self, tracked_grok_client, caplog):
         """Test Grok 3 mini model captures usage correctly."""

--- a/tests/test_grok_streaming.py
+++ b/tests/test_grok_streaming.py
@@ -40,7 +40,12 @@ class TestGrokStreaming:
     @pytest.fixture
     def tracked_grok_client(self, grok_client):
         """Create a tracked Grok client."""
-        return LLMTrackingProxy(grok_client, provider=Provider.XAI, debug=True)
+        return LLMTrackingProxy(
+            grok_client,
+            provider=Provider.OPENAI,
+            base_url="https://api.x.ai/v1",
+            debug=True,
+        )
 
     def test_grok_streaming_basic(self, tracked_grok_client, caplog):
         """Test basic Grok streaming functionality."""

--- a/tests/test_proxy_new_features.py
+++ b/tests/test_proxy_new_features.py
@@ -21,11 +21,26 @@ class MockClient:
             "completion_tokens": 20,
             "total_tokens": 30,
         }
+        self._is_openai_mock = True
         self.model = "test-model"
         self.id = "test-response-id"
 
     def chat_completion(self, **kwargs):
         """Mock chat completion method."""
+        return self
+
+
+class MockResponsesClient(MockClient):
+    """Mock client mimicking OpenAI responses API."""
+
+    def __init__(self):
+        super().__init__()
+        self.responses = self
+
+    def __str__(self):
+        return "responses"
+
+    def create(self, **kwargs):  # noqa: D401 - mimic openai responses.create
         return self
 
 
@@ -280,3 +295,66 @@ class TestProxyNewFeatures:
             proxy.chat_completion()
             second_payload = mock_tracker.track.call_args_list[1][0][0]
             assert second_payload["context"] == {"second": True}
+
+    def test_base_url_not_in_payload_by_default(self):
+        mock_client = MockClient()
+
+        with patch("llmcosts.tracker.proxy.get_usage_tracker") as mock_get_tracker:
+            mock_tracker = MagicMock()
+            mock_get_tracker.return_value = mock_tracker
+
+            proxy = LLMTrackingProxy(mock_client, provider=Provider.OPENAI)
+
+            proxy.chat_completion()
+            payload = mock_tracker.track.call_args[0][0]
+            assert "base_url" not in payload
+
+    def test_base_url_added_when_set(self):
+        mock_client = MockClient()
+
+        with patch("llmcosts.tracker.proxy.get_usage_tracker") as mock_get_tracker:
+            mock_tracker = MagicMock()
+            mock_get_tracker.return_value = mock_tracker
+
+            proxy = LLMTrackingProxy(
+                mock_client,
+                provider=Provider.OPENAI,
+                base_url="https://api.example.com/v1",
+            )
+
+            proxy.chat_completion()
+            payload = mock_tracker.track.call_args[0][0]
+            assert payload["base_url"] == "https://api.example.com/v1"
+
+    def test_base_url_setter(self):
+        mock_client = MockClient()
+        with patch("llmcosts.tracker.proxy.get_usage_tracker") as mock_get_tracker:
+            mock_tracker = MagicMock()
+            mock_get_tracker.return_value = mock_tracker
+
+            proxy = LLMTrackingProxy(mock_client, provider=Provider.OPENAI)
+
+            assert proxy.base_url is None
+            proxy.base_url = "https://api.deepseek.com/v1"
+            assert proxy.base_url == "https://api.deepseek.com/v1"
+
+            proxy.chat_completion()
+            payload = mock_tracker.track.call_args[0][0]
+            assert payload["base_url"] == "https://api.deepseek.com/v1"
+
+    def test_base_url_ignored_for_responses_api(self):
+        mock_client = MockResponsesClient()
+
+        with patch("llmcosts.tracker.proxy.get_usage_tracker") as mock_get_tracker:
+            mock_tracker = MagicMock()
+            mock_get_tracker.return_value = mock_tracker
+
+            proxy = LLMTrackingProxy(
+                mock_client,
+                provider=Provider.OPENAI,
+                base_url="https://api.example.com/v1",
+            )
+
+            proxy.responses.create(model="gpt-4")
+            payload = mock_tracker.track.call_args[0][0]
+            assert "base_url" not in payload


### PR DESCRIPTION
## Summary
- allow `LLMTrackingProxy` to accept a `base_url` parameter with getter/setter
- include `base_url` in OpenAI usage payloads (except Responses API)
- document using `base_url` for DeepSeek and Grok
- update Grok/DeepSeek tests to use the new parameter
- add unit tests for `base_url` behaviour

## Testing
- `pytest tests/test_proxy_new_features.py::TestProxyNewFeatures::test_base_url_added_when_set -q`
- `pytest tests/test_proxy_new_features.py::TestProxyNewFeatures::test_base_url_not_in_payload_by_default -q`
- `pytest tests/test_proxy_new_features.py::TestProxyNewFeatures::test_base_url_setter -q`
- `pytest -q` *(fails: missing optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686d5f87dc7c832bbfae2a22cfc21956